### PR TITLE
Config reverts

### DIFF
--- a/config/config/paper-global.yml
+++ b/config/config/paper-global.yml
@@ -38,7 +38,7 @@ commands:
 console:
   enable-brigadier-completions: true
   enable-brigadier-highlighting: true
-  has-all-permissions: true
+  has-all-permissions: false
 item-validation:
   book:
     author: 8192
@@ -52,7 +52,7 @@ item-validation:
   resolve-selectors-in-books: false
 logging:
   deobfuscate-stacktraces: true
-  log-player-ip-addresses: false
+  log-player-ip-addresses: true
   use-rgb-for-named-text-colors: true
 messages:
   kick:
@@ -113,13 +113,13 @@ timings:
   - proxies.velocity.secret
   history-interval: 300
   history-length: 3600
-  server-name: Awooo
+  server-name: Unknown Server
   server-name-privacy: false
   url: https://timings.aikar.co/
   verbose: true
 unsupported-settings:
-  allow-headless-pistons: true
-  allow-permanent-block-break-exploits: true
+  allow-headless-pistons: false
+  allow-permanent-block-break-exploits: false
   allow-piston-duplication: false
   perform-username-validation: true
 watchdog:

--- a/config/config/paper-global.yml
+++ b/config/config/paper-global.yml
@@ -118,8 +118,8 @@ timings:
   url: https://timings.aikar.co/
   verbose: true
 unsupported-settings:
-  allow-headless-pistons: false
-  allow-permanent-block-break-exploits: false
+  allow-headless-pistons: true
+  allow-permanent-block-break-exploits: true
   allow-piston-duplication: false
   perform-username-validation: true
 watchdog:

--- a/config/config/paper-world-defaults.yml
+++ b/config/config/paper-world-defaults.yml
@@ -257,7 +257,7 @@ scoreboards:
   allow-non-player-entities-on-scoreboards: true
   use-vanilla-world-scoreboard-name-coloring: false
 spawn:
-  allow-using-signs-inside-spawn-protection: true
+  allow-using-signs-inside-spawn-protection: false
   keep-spawn-loaded: true
   keep-spawn-loaded-range: 10
 tick-rates:

--- a/config/plugins/DiscordSRV/config.yml
+++ b/config/plugins/DiscordSRV/config.yml
@@ -203,7 +203,7 @@ DiscordConsoleChannelLogRefreshRateInSeconds: 5
 DiscordConsoleChannelUsageLog: "Console-%date%.log"
 DiscordConsoleChannelBlacklistActsAsWhitelist: false
 DiscordConsoleChannelBlacklistedCommands: ["?", "op", "deop", "execute"]
-DiscordConsoleChannelFilters: {"\\[\\/[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+(?::[0-9]+)?\\]": "", ".*ERROR DiscordSRV.*": ""}
+DiscordConsoleChannelFilters: {".*ERROR DiscordSRV.*": ""}
 DiscordConsoleChannelLevels: [info, warn, error]
 DiscordConsoleChannelUseCodeBlocks: true
 DiscordConsoleChannelAllowPluginUpload: false


### PR DESCRIPTION
## paper-global.yml

### console.has-all-permissions

From what i know we don't need this

### logging.log-player-ip-addresses

imo its better to log than not. Its really good for investigating things that happen on the server. If someone does get ips all they can really do is get some geo data. I really doubt someone would resort to DDOSing. And if that was the cause all you have to do is get a new ip. If we just want IPs shown to sys-admins we can always keep the DiscordSRV filter for ip addresses on

### timings.server-name

Not documented and only related to timings

### unsupported-settings.allow-permanent-block-break-exploits

It says in the pinned issue on the paper github (3854) that enabling the config option means we will not receive support from paper

### unsupported-settings.allow-headless-pistons

On the paper github pull request 3565, setting unsupported-settings option to settings other than the default means we shouldn't expect support from paper

## paper-world-defaults.yml

### spawn.allow-using-signs-inside-spawn-protection

spawn-protection in server.properties is set to 0 so this should be fine as false?

## DiscordSRV - config.yml

### DiscordConsoleChannelFilters

Allow discord admins to see ips. If keeping ```logging.log-player-ip-addresses: false``` there is no need to filter here